### PR TITLE
Use UUIDs for identification

### DIFF
--- a/pages/api/ballot/index.js
+++ b/pages/api/ballot/index.js
@@ -11,7 +11,7 @@ module.exports = async (req, res) => {
         total_votes,
         votes_made
       FROM voters
-      WHERE id = ${parseInt(id)}
+      WHERE uuid = ${id}
     `);
     const stories = await db.query(escape`
       SELECT
@@ -23,4 +23,4 @@ module.exports = async (req, res) => {
   } catch (error) {
     res.status(500).json({ error, message: 'Something went wrong getting the stories '});
   }
- }; 
+ };

--- a/pages/api/login.js
+++ b/pages/api/login.js
@@ -34,7 +34,7 @@ module.exports = async (req, res) => {
     if ( user.votes_made >= user.total_votes ) {
       redirectTo(res, "/thank-you")
     } else {
-      redirectTo(res, "/ballot")
+      redirectTo(res, `/ballot?shipster=${user.uuid}`)
     }
   } else {
     // If we don't have a POST request we'd like to redirect to login


### PR DESCRIPTION
This PR:
- Adds the `shipster` param when redirecting to the ballot from login
- Modifies the ballot API to validate a user via UUID instead of ID